### PR TITLE
Expand peerDependencies range to include webpack v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "release": "wnpm-release"
   },
   "peerDependencies": {
-    "webpack": "^3.0.0 || ^4.0.0"
+    "webpack": "^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "devDependencies": {
     "jest": "~22.0.0",


### PR DESCRIPTION
### Summary

We currently don't use any APIs that don't work on webpack v5, and this helps Yarn/npm have less dependencies while hoisting.
